### PR TITLE
Add support for pipeline single line declaration

### DIFF
--- a/plai/interpreter.py
+++ b/plai/interpreter.py
@@ -58,7 +58,7 @@ def eval(sexpr, e=None, **kwargs):
         return dataframe.assign(**{str(name): result})
 
     elif head == Symbol.PIPELINE:
-        pipeline_args, *block = sargs
+        pipeline_args, block = sargs
         dataframe = eval(*pipeline_args, e, **kwargs)
 
         for stmt in block:

--- a/plai/parser.py
+++ b/plai/parser.py
@@ -26,9 +26,9 @@ arguments : argvalue("," argvalue)*
 
 pipeline : "pipeline" "(" arguments+ ")" ":" suite
 
-?suite : simple_stmt | _NL _INDENT stmt+ _DEDENT
+suite : _simple_stmt | _NL _INDENT stmt+ _DEDENT
 
-?simple_stmt : single_stmt(";" single_stmt)*
+_simple_stmt : single_stmt(";" single_stmt)*
 
 alias_expr : expr ("as" var)
 
@@ -123,9 +123,6 @@ class PlaiTransformer(InlineTransformer):
         return ast.literal_eval(token)
 
     def suite(self, *sargs):
-        return [*sargs]
-
-    def simple_stmt(self, *sargs):
         return [*sargs]
 
     def or_expr(self, right, left):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -110,20 +110,34 @@ class TestFunctionCall:
 class TestPipeline:
     def test_pipeline_raise_error_on_undeclared_dataframe(self):
         with pytest.raises(NameError):
-            run('pipeline(df): \n\tdrop(.name)')
+            src = """
+pipeline(df):
+    drop(.name)
+"""
+            run(src)
 
     def test_pipeline_execute_stmts(self, dataframe):
         e = env()
         e[Symbol('df')] = dataframe
+        src = """
+pipeline(df):
+    drop(.name)
+"""
+        res = run(src, env=e)
 
-        assert run('pipeline(df): \n\tdrop(.name)', env=e).equals(
+        assert res.equals(
             drop(Col('name', dataframe), **{'dataframe': dataframe}))
 
     def test_pipeline_execute_multiple_stmts(self, dataframe):
         e = env()
         e[Symbol('df')] = dataframe
+        src = """
+pipeline(df):
+    drop(.name)
+    drop(.floats)
+"""
 
-        assert run('pipeline(df): \n\tdrop(.name) \n\tdrop(.floats)', env=e).equals(
+        assert run(src, env=e).equals(
             drop(Col('name', dataframe), Col('floats', dataframe), **{'dataframe': dataframe}))
 
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -130,16 +130,6 @@ b = 3
     def test_one_stmt(self):
         assert parse('1 + 1') == [Symbol('+'), 1, 1]
 
-    def test_one_line_stmts(self):
-        res = parse('pipeline(df): .col + 1;.col + 2')
-        assert res == [
-            Symbol.PIPELINE,
-            [Symbol('df')],
-            [
-                [Symbol('+'), [Symbol.COLUMN, 'col'], 1],
-                [Symbol('+'), [Symbol.COLUMN, 'col'], 2]
-            ]
-        ]
 
 
 class TestFunctionCall:
@@ -211,7 +201,7 @@ pipeline(bar):
         assert parse(src) == [
             Symbol.PIPELINE,
             [Symbol('bar')],
-            [Symbol('foo')]
+            [[Symbol('foo')]]
         ]
 
     def test_sugar_column_call(self):
@@ -223,6 +213,24 @@ pipeline(bar):
 
         with pytest.raises(UnexpectedToken):
             parse('.()')
+
+    def test_one_line_stmt_on_pipeline(self):
+        assert parse('pipeline(df): .col + 1') == [
+            Symbol.PIPELINE,
+            [Symbol('df')],
+            [[Symbol('+'), [Symbol.COLUMN, 'col'], 1]]
+        ]
+
+    def test_one_line_stmts_on_pipeline(self):
+        res = parse('pipeline(df): .col + 1;.col + 2')
+        assert res == [
+            Symbol.PIPELINE,
+            [Symbol('df')],
+            [
+                [Symbol('+'), [Symbol.COLUMN, 'col'], 1],
+                [Symbol('+'), [Symbol.COLUMN, 'col'], 2]
+            ]
+        ]
 
     def test_multiple_stmts_on_pipeline(self):
         src = """


### PR DESCRIPTION
Pipelines can now be declared as follows:
```
pipeline(df): .col + 'foo' as foo_column; {.foo_column, .col}
```